### PR TITLE
Bug fixes and switch to terra package

### DIFF
--- a/pipeline/import/speciesImport.R
+++ b/pipeline/import/speciesImport.R
@@ -17,8 +17,8 @@ library(rinat)
 ###-----------------###
 
 # Run script to define geographical region and resolution we are working with 
-if (!exists(level)) {level <- "county"}  # level can be country, county, municipality, or points (examples of points given below)
-if (!exists(region)) {region <- "50"}
+if (!exists("level")) {level <- "county"}  # level can be country, county, municipality, or points (examples of points given below)
+if (!exists("region")) {region <- "50"}
 runBuffer <- FALSE
 #points <- c(4.641979, 57.97976, 31.05787, 71.18488)
 #names(points) <- c("north", "south", "east", "west")

--- a/pipeline/import/speciesImport.R
+++ b/pipeline/import/speciesImport.R
@@ -98,7 +98,7 @@ names(GBIFLists) <- unique(GBIFImportCompiled$name)
 ###----------------###
 
 source("utils/importANOData.R")
-if(exists("ANOData")) GBIFLists[["ANOData"]] <- ANOData
+if(exists("ANOData")) {GBIFLists[["ANOData"]] <- ANOData}
 
 
 ###--------------------###

--- a/pipeline/import/speciesImport.R
+++ b/pipeline/import/speciesImport.R
@@ -98,7 +98,7 @@ names(GBIFLists) <- unique(GBIFImportCompiled$name)
 ###----------------###
 
 source("utils/importANOData.R")
-GBIFLists[["ANOData"]] <- ANOData
+if(exists("ANOData")) GBIFLists[["ANOData"]] <- ANOData
 
 
 ###--------------------###

--- a/pipeline/models/speciesModelRuns.R
+++ b/pipeline/models/speciesModelRuns.R
@@ -34,7 +34,8 @@ focalTaxa <- unique(focalSpecies$taxonomicGroup)
 
 # Import datasets
 regionGeometry <- readRDS(paste0(folderName, "/regionGeometry.RDS"))
-environmentalDataList <- readRDS(paste0(tempFolderName, "/environmentalDataImported.RDS"))
+# environmentalDataList <- readRDS(paste0(tempFolderName, "/environmentalDataImported.RDS"))
+environmentalDataList <- rast(paste0(tempFolderName, "/environmentalDataImported.tiff"))
 
 if (externalImport == TRUE) {
   

--- a/utils/importANOData.R
+++ b/utils/importANOData.R
@@ -43,29 +43,32 @@ ANOSpeciesFull <- ANOSpeciesFull[,c("GlobalID", "ParentGlobalID", "simpleScienti
 # Narrow down to only species we are looking for
 ANOSpecies <- ANOSpeciesFull[ANOSpeciesFull$simpleScientificName %in% focalSpecies$species,]
 
-# Start creating a matrix of species occurrence
-ANOSpeciesTable <- as.data.frame(table(ANOSpecies$ParentGlobalID, ANOSpecies$simpleScientificName), 
+# continue only if at least one species is present in ANO
+if(nrow(ANOSpecies) > 0) {
+  # Start creating a matrix of species occurrence
+  ANOSpeciesTable <- as.data.frame(table(ANOSpecies$ParentGlobalID, ANOSpecies$simpleScientificName), 
                                    stringsAsFactors = FALSE)
-# Convert anything more than 2 to a presence
-ANOSpeciesTable$Freq[ANOSpeciesTable$Freq > 0] <- 1
-colnames(ANOSpeciesTable) <- c("GlobalID", "simpleScientificName", "individualCount")
-
-# Add geometry data
-ANOData <- merge(ANOSpeciesTable, ANOPoints[,c("GlobalID")], 
-                 by="GlobalID", all.x=TRUE)
-ANOData$dataType <- "PA"
-ANOData$name <- "ANO Data"
-ANOData$geometry <- ANOData$SHAPE
-ANOData$DWCEndpoint <- ANOEndpoint
-ANOData$basisofRecord <- "HUMAN_OBSERVATION"
-ANOData$type <- "SAMPLING_EVENT"
-ANOData$datasetKey <- ANOData$coordinateUncertaintyInMeters <- ANOData$year <- NA
-
-ANOData <- st_as_sf(ANOData)
-st_crs(ANOData) <- "+proj=longlat +ellps=WGS84"
-
-# Crop to relevant region
-ANOData <- st_intersection(ANOData, regionGeometry)
-ANOData <- st_transform(ANOData, crs = "+proj=longlat +datum=WGS84 +no_defs +ellps=WGS84 +towgs84=0,0,0 ")
-
-rm("ANOSpecies", "ANOSpeciesTable", "ANOSpeciesFull", "ANOPoints", "ANOUnzippedFolder", "tempANOFolder")
+  # Convert anything more than 2 to a presence
+  ANOSpeciesTable$Freq[ANOSpeciesTable$Freq > 0] <- 1
+  colnames(ANOSpeciesTable) <- c("GlobalID", "simpleScientificName", "individualCount")
+  
+  # Add geometry data
+  ANOData <- merge(ANOSpeciesTable, ANOPoints[,c("GlobalID")], 
+                   by="GlobalID", all.x=TRUE)
+  ANOData$dataType <- "PA"
+  ANOData$name <- "ANO Data"
+  ANOData$geometry <- ANOData$SHAPE
+  ANOData$DWCEndpoint <- ANOEndpoint
+  ANOData$basisofRecord <- "HUMAN_OBSERVATION"
+  ANOData$type <- "SAMPLING_EVENT"
+  ANOData$datasetKey <- ANOData$coordinateUncertaintyInMeters <- ANOData$year <- NA
+  
+  ANOData <- st_as_sf(ANOData)
+  st_crs(ANOData) <- "+proj=longlat +ellps=WGS84"
+  
+  # Crop to relevant region
+  ANOData <- st_intersection(ANOData, regionGeometry)
+  ANOData <- st_transform(ANOData, crs = "+proj=longlat +datum=WGS84 +no_defs +ellps=WGS84 +towgs84=0,0,0 ")
+  
+  rm("ANOSpecies", "ANOSpeciesTable", "ANOSpeciesFull", "ANOPoints", "ANOUnzippedFolder", "tempANOFolder")
+}

--- a/utils/importANOData.R
+++ b/utils/importANOData.R
@@ -14,7 +14,7 @@ if (!file.exists(tempANOFolder)) {
 # Download and unzip ANO data from endpoint
 ANOEndpoint <- "https://nedlasting.miljodirektoratet.no/naturovervaking/naturovervaking_eksport.gdb.zip"
 ANOfile <- download.file(url=ANOEndpoint, 
-                         destfile=paste0(tempANOFolder, "/naturovervaking_eksport.gdb.zip"))
+                         destfile=paste0(tempANOFolder, "/naturovervaking_eksport.gdb.zip"), mode = "wb")
 unzip(paste0(tempANOFolder, "/naturovervaking_eksport.gdb.zip"), 
       exdir = tempANOFolder)
 ANOUnzippedFolder <- paste0(tempANOFolder, "/Naturovervaking_eksport.gdb")

--- a/utils/installAllPackages.R
+++ b/utils/installAllPackages.R
@@ -13,7 +13,7 @@ if(!("intSDM" %in% row.names(installedPackages))) {
 
 # Now we bring int he rest of the necessary packages
 necessaryPackages <- c("rgbif", "sf", "stringr", "dplyr", "rinat", "raster", "csmaps", "ggplot2",
-                       "shiny", "shinydashboard", "PointedSDMs",
+                       "shiny", "shinydashboard", "PointedSDMs", "terra",
                        "shinyjs", "inlabru", "randomcoloR", "plotKML")
 uninstalledPackages <- necessaryPackages[!(necessaryPackages %in% row.names(installedPackages))]
 install.packages(uninstalledPackages)

--- a/utils/meshTest.R
+++ b/utils/meshTest.R
@@ -4,12 +4,12 @@
 
 # THis file creates and visualises a very quick INLA Mesh
 
-mesh <- INLA::inla.mesh.2d(inlabru::fm_as_inla_mesh_segment(regionGeometry),
+mesh <- INLA::inla.mesh.2d(boundary = inlabru::fm_as_inla_mesh_segment(regionGeometry),
                            crs = inlabru::fm_crs('+proj=utm +zone=32 +ellps=WGS84 +datum=WGS84 +units=m +no_defs'),
                            cutoff= myMesh$cutoff, 
                            max.edge=myMesh$max.edge, 
                            offset= myMesh$offset)
 
 ggplot2::ggplot() +
-  ggplot2::geom_sf(data = sf::st_boundary(regionGeometry)) +
+  ggplot2::geom_sf(data = st_transform(regionGeometry, mesh$crs)) +
   inlabru::gg(mesh)

--- a/utils/meshTest.R
+++ b/utils/meshTest.R
@@ -10,6 +10,6 @@ mesh <- INLA::inla.mesh.2d(boundary = inlabru::fm_as_inla_mesh_segment(regionGeo
                            max.edge=myMesh$max.edge, 
                            offset= myMesh$offset)
 
-ggplot2::ggplot() +
+print(ggplot2::ggplot() +
   ggplot2::geom_sf(data = st_transform(regionGeometry, mesh$crs)) +
-  inlabru::gg(mesh)
+  inlabru::gg(mesh))

--- a/utils/modelPreparation.R
+++ b/utils/modelPreparation.R
@@ -52,8 +52,9 @@ for (i in 1:length(focalTaxa)) {
   }
   
   # Add environmental characteristics
-  for (e in 1:length(environmentalDataList)) {
-       workflow$addCovariates(Object = environmentalDataList[[e]])
+  for (e in 1:nlyr(environmentalDataList)) {
+    cat(sprintf("Adding covariate '%s' to the model.\n", names(environmentalDataList)[e]))
+    workflow$addCovariates(Object = environmentalDataList[[e]])
   }
     
   workflowList[[focalGroup]] <- workflow


### PR DESCRIPTION
# Why have changes been made?

Minor bug fixes, and replace use of raster package with terra package

# What changes have been made?

- bug fix in speciesImport, ImportANOData, and meshTest
- switch to use of terra in environmentalImport, and use of terra SpatRasters in SpeciesModelRuns in modelPreparation

note 1: I did not test out use of initiateWallaceConnection for environmental data, so I am not sure if my translation of rasterFromXYZ(dataRaw) to terra will work.
note 2: terra does not import rasters into R environment, so saveRDS() does not work on terra SpatRasters. Instead, I opted to save parametersCropped as a .tiff, which required formatting it as a single SpatRaster with a layer for each covariate rather than a list of separate raster objects. This required standardizing all covariates to same projection, resolution, and extent. we may want to change this in the future to use rasters in their native format without reprojecting or if some rasters will use multiple layers for different time periods (i.e., if using a spatiotemporal model).