### PR TITLE
Compile GBIF function to import one species

### DIFF
--- a/data/temp/README.md
+++ b/data/temp/README.md
@@ -1,0 +1,1 @@
+Folder for temp objects

--- a/pipeline/import/speciesImport.R
+++ b/pipeline/import/speciesImport.R
@@ -42,16 +42,9 @@ if (!file.exists(folderName)) {
 ###-----------------###
 ### 2. GBIF Import ####
 ###-----------------###
-CompileGBIFImport <- function(z) {
-  dataSubset <- z$data
-  
-  # datasetName does not exist in some species for some reason. In these cases, let it equal NA
-  if (!("datasetName" %in% colnames(dataSubset))) {
-    dataSubset$datasetName <- NA
-  }
-  dataSubset[,c("acceptedScientificName", "decimalLongitude", "decimalLatitude", "basisOfRecord", "year", 
-                "datasetKey", "coordinateUncertaintyInMeters", "datasetName")]
-}
+
+# Import GBIF compilation function
+source("utils/compileGBIFImport.R")
   
 # Import GBIF Data
 gbifImportsPerTaxa <- lapply(focalTaxa, FUN = function(x) {

--- a/pipeline/import/speciesImport.R
+++ b/pipeline/import/speciesImport.R
@@ -58,7 +58,6 @@ gbifImportsPerTaxa <- lapply(focalTaxa, FUN = function(x) {
   focalSpeciesImport <- focalSpecies$species[focalSpecies$taxonomicGroup == x]
   GBIFImport <- occ_data(scientificName = focalSpeciesImport, hasCoordinate = TRUE, limit = 3000, 
                          geometry = st_bbox(regionGeometry), coordinateUncertaintyInMeters = '0,500')
-      dataSubset$datasetName <- NA
   # compile import 
   if(all(names(GBIFImport) == c("meta", "data"))){  # if only one species selected
     GBIFImportCompiled <- CompileGBIFImport(GBIFImport)

--- a/utils/compileGBIFImport.R
+++ b/utils/compileGBIFImport.R
@@ -1,0 +1,16 @@
+
+### Compile GBIF Import ###
+
+# Function that cuts down the GBIF Import to only necessary columns
+
+
+CompileGBIFImport <- function(z) {
+  dataSubset <- z$data
+  
+  # datasetName does not exist in some species for some reason. In these cases, let it equal NA
+  if (!("datasetName" %in% colnames(dataSubset))) {
+    dataSubset$datasetName <- NA
+  }
+  dataSubset[,c("acceptedScientificName", "decimalLongitude", "decimalLatitude", "basisOfRecord", "year", 
+                "datasetKey", "coordinateUncertaintyInMeters", "datasetName")]
+}

--- a/utils/metadataProduction.Rmd
+++ b/utils/metadataProduction.Rmd
@@ -19,17 +19,17 @@ We begin with basic information about the pipeline run.
 
 ``` {r echo = FALSE}
 
-source(textConnection(readLines("../pipeline/import/speciesImport.R")[22:23]))
-focalTaxa <- read.csv("../data/external/focalTaxa.csv")
+region <- attr(speciesDataList, "region")
+level <- attr(speciesDataList, "level")
+focalSpecies <- read.csv("../data/external/focalSpecies.csv")
+focalTaxa <- unique(focalSpecies$species)
 infoNames <- c("Date",
                "Taxa",
-               "Taxa code",
                "Region type",
                "Region code",
                "Total species",
                "Total datasets used")
-info <- c(dateAccessed, paste(focalTaxa$taxa, collapse = ", "), 
-          paste(focalTaxa$key, collapse = ", "), level, region, nrow(focalSpecies),
+info <- c(dateAccessed, paste(focalTaxa, collapse = ", "), level, region, nrow(focalSpecies),
           length(unique(processedDataDF$datasetName)))
 basicInfo <- data.frame(Characteristic = infoNames, Value = info)
 knitr::kable(basicInfo)
@@ -66,8 +66,8 @@ The following gives spatial density for observations across the surveyed region 
 ``` {r echo = FALSE}
 
 regionGeometry <- readRDS(paste0("../", folderName, "/regionGeometry.RDS"))
-for (i in 1:length(unique(focalTaxa$taxa))) {
-  focalTaxaGroup <- unique(focalTaxa$taxa)[i]
+for (i in 1:length(focalTaxa)) {
+  focalTaxaGroup <- focalTaxa[i]
   processedDataShortened <- processedDataCompiled[processedDataCompiled$taxa == focalTaxaGroup,]
 print(ggplot(regionGeometry) +
       geom_sf() +


### PR DESCRIPTION
# Why have changes been made?

- speciesImport would return error when only one species is returned by occ_data.
- issue when trying to extract columns of interest using lapply that assumes each element is a species

Additionally:

- Upstream changes made to the main repo have been integrated into the fork

# What changes have been made?

- column filtering in GBIF Import moved to separate function, that is called directly when only one species is returned by occ_data, or using lapply when multiple species are returned

