### PR TITLE
Change Norwegian region import

### DIFF
--- a/functions/import/species/defineRegion.R
+++ b/functions/import/species/defineRegion.R
@@ -16,9 +16,9 @@ if (level == "municipality") {
   regionCode <- paste0("county_nor", region)
   regionGeometry <- nor_county_map_b2020_default_sf$geometry[nor_county_map_b2020_default_sf$location_code == regionCode]
 } else if (level == "country") {
-  regionGeometry <- st_combine(nor_county_map_b2020_default_sf$geometry)
-  # ALso need to remove internal borders
-  regionGeometry <- st_union(st_make_valid(regionGeometry))
+  world <- giscoR::gisco_get_countries()
+  Norway <- world[world$NAME_ENGL == 'Norway',]
+  regionGeometry <- st_transform(Norway$geometry,crs = "+proj=longlat +datum=WGS84 +no_defs")
 } else {
     ## create a matrix of coordinates that also 'close' the polygon
     res <- matrix(c(extentCoords['north'], extentCoords['west'],


### PR DESCRIPTION
# Why have changes been made?

The previous import of the regionGeometry for the whole of Norway was a bit wonky, it's fixed here.

# What changes have been made?

- functions/import/species/defineRegion.R - Now uses gisco package to give complete multipolygon for Norway
