### PR TITLE
Add year to processed species data

### DIFF
--- a/functions/import/species/importANOData.R
+++ b/functions/import/species/importANOData.R
@@ -37,16 +37,17 @@ importANOData <- function(focalSpecies, destinationFolder, regionGeometry,
                                       substring(ANOSpeciesFull$art_navn, 2), 
                                       sep="")
   ANOSpeciesFull$simpleScientificName <- gsub(" ", "_", word(ANOSpeciesFull$SpeciesName, 1,2, sep=" "))
-  ANOSpeciesFull <- ANOSpeciesFull[,c("GlobalID", "ParentGlobalID", "simpleScientificName")]
+  ANOSpeciesFull$year <- format(ANOSpeciesFull$EditDate, format="%Y")
+  ANOSpeciesFull <- ANOSpeciesFull[,c("GlobalID", "ParentGlobalID", "simpleScientificName", "year")]
   
   # Narrow down to only species we are looking for
   ANOSpecies <- ANOSpeciesFull[ANOSpeciesFull$simpleScientificName %in% focalSpecies$species,]
   
-  ANOSpeciesTable <- as.data.frame(table(ANOSpecies$ParentGlobalID, ANOSpecies$simpleScientificName), 
+  ANOSpeciesTable <- as.data.frame(table(ANOSpecies$ParentGlobalID, ANOSpecies$simpleScientificName, ANOSpecies$year), 
                                    stringsAsFactors = FALSE)
   # Convert anything more than 2 to a presence
   ANOSpeciesTable$Freq[ANOSpeciesTable$Freq > 0] <- 1
-  colnames(ANOSpeciesTable) <- c("GlobalID", "simpleScientificName", "individualCount")
+  colnames(ANOSpeciesTable) <- c("GlobalID", "simpleScientificName", "year", "individualCount")
   
   # Add geometry data
   ANOData <- merge(ANOSpeciesTable, ANOPoints[,c("GlobalID")], 

--- a/functions/integration/presenceAbsenceConversion.R
+++ b/functions/integration/presenceAbsenceConversion.R
@@ -44,6 +44,7 @@ presenceAbsenceConversion <- function(focalEndpoint, tempFolderName, datasetName
                          by.x = c("simpleScientificName", "eventID"), by.y = c("species", "eventID"))
   mergedSpecies$individualCount <- ifelse(is.na(mergedSpecies$occurrenceID), 0, 1)
   mergedSpecies <- mergedSpecies[!is.na(mergedSpecies$longitude),]
+  mergedSpecies$year <- events$year[match(mergedSpecies$eventID, events$id)]
   
   # New dataset is ready!
   newDataset <- st_as_sf(mergedSpecies,                         
@@ -57,6 +58,6 @@ presenceAbsenceConversion <- function(focalEndpoint, tempFolderName, datasetName
   newDataset <- st_intersection(newDataset, regionGeometry)
   newDataset <- st_transform(newDataset, crs = "+proj=longlat +datum=WGS84 +no_defs +ellps=WGS84 +towgs84=0,0,0 ")
   newDataset$taxa <- focalSpecies$taxonomicGroup[match(newDataset$simpleScientificName, focalSpecies$species)]
-  newDataset <- newDataset[,c("simpleScientificName", "individualCount", "geometry", "dataType", "taxa")]
+  newDataset <- newDataset[,c("simpleScientificName", "individualCount", "geometry", "dataType", "taxa", "year")]
   return(newDataset)
 }

--- a/functions/integration/processANOData.R
+++ b/functions/integration/processANOData.R
@@ -21,6 +21,6 @@ processANOData <- function(ANODataset, regionGeometry, focalSpecies) {
   
   
   ANODataset$taxa <- focalSpecies$taxonomicGroup[match(ANODataset$simpleScientificName, focalSpecies$species)]
-  ANODataset <- ANODataset[,c("simpleScientificName", "individualCount", "geometry", "dataType", "taxa")]
+  ANODataset <- ANODataset[,c("simpleScientificName", "individualCount", "geometry", "dataType", "taxa", "year")]
   return(ANODataset)
 }

--- a/functions/integration/processNationalinsectmonitoringinNorway.R
+++ b/functions/integration/processNationalinsectmonitoringinNorway.R
@@ -47,12 +47,13 @@ processNationalInsectMonitoring <- function(endpoint, tempFolderName, focalSpeci
   occurrencesWithEvent$exactDate <- as.Date(substr(occurrencesWithEvent$eventDate,1,10))
   occurrencesMostRecent <- occurrencesWithEvent %>%
     group_by(scientificName, locationID) %>%
-    slice_max(exactDate, n = 1) %>% 
+    slice_max(exactDate, n = 1,na_rm = TRUE) %>% 
     ungroup()
   occurrencesMostRecent <- occurrencesMostRecent[!duplicated(occurrencesMostRecent[,c("scientificName", "locationID")]),]
+  occurrencesMostRecent$year <- substr(occurrencesMostRecent$exactDate, 1, 4)
   
   # The resulting data frame gives you results for the most recent individual insect abundances at each site
-  ourDataset <- occurrencesMostRecent[,c("scientificName", "organismQuantity", "decimalLatitude", "decimalLongitude", "locationID")]
+  ourDataset <- occurrencesMostRecent[,c("scientificName", "organismQuantity", "decimalLatitude", "decimalLongitude", "locationID", "year")]
   ourDataset <- ourDataset %>% 
     mutate(simpleScientificName = gsub(" ", "_", scientificName)) %>%
     filter(simpleScientificName %in% ourSurveyedSpecies)
@@ -64,7 +65,7 @@ processNationalInsectMonitoring <- function(endpoint, tempFolderName, focalSpeci
   # as used in the presenceAbsenceCOnversion.R script.
   allSpecies <- expand.grid(simpleScientificName = ourSurveyedSpecies,
                             locationID = unique(ourDataset$locationID))
-  mergedDataset <- merge(allSpecies, ourDataset[,c("locationID", "simpleScientificName", "organismQuantity")], 
+  mergedDataset <- merge(allSpecies, ourDataset[,c("locationID", "simpleScientificName", "organismQuantity", "year")], 
                          all.x = TRUE, by = c("locationID", "simpleScientificName"))
   mergedDataset <- merge(mergedDataset, locations,
                          all.x = TRUE, by = "locationID")
@@ -77,7 +78,7 @@ processNationalInsectMonitoring <- function(endpoint, tempFolderName, focalSpeci
                          crs = "+proj=longlat +datum=WGS84 +no_defs +ellps=WGS84 +towgs84=0,0,0")
   
   
-  newDataset <- newDataset[c("simpleScientificName", "organismQuantity")] %>%
+  newDataset <- newDataset[c("simpleScientificName", "organismQuantity", "year")] %>%
     rename(individualCount = organismQuantity)
   
   

--- a/pipeline/integration/speciesDataProcessing.R
+++ b/pipeline/integration/speciesDataProcessing.R
@@ -61,7 +61,7 @@ for (ds in 1:length(speciesData)) {
   # 1. First condition - is there a pre-set script for this dataset?
   if (gsub(" ","",datasetName) %in% processingScripts) {
     source("pipeline/integration/utils/defineProcessing.R")
-  } else if (dataType == "PA" & datasetName != "ANOData") { 
+  } else if (dataType == "PA") { 
   # 2. Second condition - is it presence-absence?
     # Here we apply our conversion script for presence/absence data - tryCatch is for if any links to endpoints are broken
     focalEndpoint <- metadata$DWCEndpoint[metadata$name == datasetName]
@@ -78,7 +78,7 @@ for (ds in 1:length(speciesData)) {
   # 3. Doesn't satisfy the other two, which means it must be presence only 
     
     # No need to do anything to presence only data (yet) except add individualCount column
-    newDataset <- focalData[,c("simpleScientificName", "geometry", "dataType", "taxa")]
+    newDataset <- focalData[,c("simpleScientificName", "geometry", "dataType", "taxa", "year")]
   }
   processedData[[ds]] <- newDataset
   namesProcessedData[ds] <- datasetName


### PR DESCRIPTION
# Why have changes been made?

While it may not be necessary right now, in the future we will want to run models which can adapt the environmental covariates based on the year of the observation. As such, I'm bringing in year data now.

# What changes have been made?

- functions/integration/presenceAbsenceConversion.R - added year data in from the events table based on eventID
- functions/import/species/importANOData.R - simply retained year data
- functions/integration/processANOData.R - as above
- functions/integration/processNationalinsectmonitoringinNorway.R - bit more tricky, had to ensure year data was added in several places
- pipeline/integration/speciesDataProcessing.R retained year data (and got rid of superfluous condition for ANOData)