### PR TITLE
Improved human density script

### DIFF
--- a/functions/import/environment/get_ssb.R
+++ b/functions/import/environment/get_ssb.R
@@ -1,41 +1,23 @@
 # function derives values found on this page: https://www.ssb.no/natur-og-miljo/geodata and 
 # at https://kartkatalog.geonorge.no/metadata/befolkning-paa-rutenett-1000m-2016-2019-wfs/20d06bca-484c-4353-a24b-61046296f5da
 
-get_ssb <- function(focalParameter, rutenett = NA, getRutenett = TRUE, resolution = "1000") {
+get_ssb <- function(focalParameter, resolution = "1000") {
   
   # Define endpoints for different resolutions and variables
-  resolutionFileCheck <- data.frame(human_density = c("https://www.ssb.no/natur-og-miljo/_attachment/389479?_ts=16b45e39840",
-                                                      "https://www.ssb.no/natur-og-miljo/_attachment/389480?_ts=16b45e3cef0"),
-                                    building_density = c("https://www.ssb.no/natur-og-miljo/_attachment/461715?_ts=17edde4d2e0",
-                                                         "https://www.ssb.no/natur-og-miljo/_attachment/461716?_ts=17edde501c0"),
+  resolutionFileCheck <- data.frame(human_density = c("http://wfs.geonorge.no/skwms1/wfs.befolkningsstatistikkrutenett250mhistorisk?service=wfs&Version=2.0.0&request=GetCapabilities",
+                                                      "https://wfs.geonorge.no/skwms1/wfs.befolkningsstatistikkrutenett1kmhistorisk?service=WFS&Version=2.0.0&request=GetCapabilities"),
+                                    building_density = c("https://wfs.geonorge.no/skwms1/wfs.bygningsstatistikkrutenett250m?service=WFS&request=GetCapabilities",
+                                                         "https://wfs.geonorge.no/skwms1/wfs.bygningsstatistikkrutenett1000m?service=WFS&Version=2.0.0&request=GetCapabilities"),
                                     row.names = c("250", "1000"))
   focalEndpoint <- resolutionFileCheck[resolution, focalParameter]
   
-  # Check if rutenett is provided, if not, download from SSB and save locally
-  if (getRutenett == TRUE) { 
-    download.file("https://www.ssb.no/natur-og-miljo/_attachment/375076?_ts=1685c0b8770", 
-                  destfile = "data/temp/ssb/rutenett.zip", mode = "wb")
-    fileNames <- unzip("data/temp/ssb/rutenett.zip", exdir = "data/temp/ssb", list = TRUE)
-    shpFile <- fileNames$Name[grepl(".shp", fileNames$Name) & !grepl(".shp.xml", fileNames$Name)]
-    unzip("data/temp/ssb/rutenett.zip", exdir = "data/temp/ssb")
-    rutenett <- read_sf(paste0("data/temp/ssb/",shpFile))[,c("geometry", "SSBid")]
-    saveRDS(rutenett, "data/temp/ssb/rutenett.RDS")
-  }
+  V0 <- vect(paste0("WFS:", focalEndpoint))
   
-  # Download csv file for relevant variable  with values
-  download.file(focalEndpoint, destfile = paste0(tempFolderName, focalParameter, ".zip"), mode= "wb")
-  fileName <- unzip(paste0(tempFolderName, focalParameter, ".zip"), list = TRUE)
-  unzip(paste0(tempFolderName, focalParameter, ".zip"), exdir = paste0(tempFolderName, "ssb"))
-  values <- read.csv(paste0(tempFolderName, "ssb/", fileName$Name), sep = ";") %>%
-    dplyr::select(1,2)
-  colnames(values) <- c("SSBId", "value")
+  # Project onto our rasters
+  R0 <- rast("data/external/environmentalCovariates/aspect.tiff")
+  R2 <- terra::rasterize(project(V0,R0), R0, field = "bui0all")
+  R3 <- lapp(R2, function(x) ifelse(is.na(x), 0, x))
   
-  # Match to rutenett
-  rutenett$value <- values$value[match(rutenett$SSBid, values$SSBId)]
-  rutenett$value[is.na(rutenett$value)] <- 0
-  
-  rasterSample <- raster("data/external/environmentalCovariates/aspect.tiff")
-  rasterizedVersion <- rast(fasterize(sf = rutenett, raster = rasterSample, field = "value"))
-  return(rasterizedVersion)
+  return(R3)
   
 }

--- a/functions/import/environment/get_ssb.R
+++ b/functions/import/environment/get_ssb.R
@@ -11,6 +11,8 @@ get_ssb <- function(focalParameter, resolution = "1000") {
                                     row.names = c("250", "1000"))
   focalEndpoint <- resolutionFileCheck[resolution, focalParameter]
   
+  message(paste0("Currently downloading ", gsub("_", " ", focalParameter), " at resolution of ", resolution, " from SSB"))
+  
   V0 <- vect(paste0("WFS:", focalEndpoint))
   
   # Project onto our rasters

--- a/functions/import/environment/get_ssb.R
+++ b/functions/import/environment/get_ssb.R
@@ -17,7 +17,8 @@ get_ssb <- function(focalParameter, resolution = "1000") {
   
   # Project onto our rasters
   R0 <- rast("data/external/environmentalCovariates/aspect.tiff")
-  R2 <- terra::rasterize(project(V0,R0), R0, field = "bui0all")
+  parameterField <- ifelse(focalParameter == "human_density", "popTot", "bui0all")
+  R2 <- terra::rasterize(project(V0,R0), R0, field = parameterField)
   R3 <- lapp(R2, function(x) ifelse(is.na(x), 0, x))
   
   return(R3)

--- a/pipeline/import/utils/defineEnvSource.R
+++ b/pipeline/import/utils/defineEnvSource.R
@@ -52,5 +52,5 @@ if (dataSource == "geonorge") {
   
 ### 3. SSB ####
 } else if (dataSource == "ssb") {
-    rasterisedVersion <- get_ssb(focalParameter, regionGeometry)
+    rasterisedVersion <- get_ssb(focalParameter, regionGeometry, resolution = "250")
 }

--- a/pipeline/import/utils/defineEnvSource.R
+++ b/pipeline/import/utils/defineEnvSource.R
@@ -52,5 +52,5 @@ if (dataSource == "geonorge") {
   
 ### 3. SSB ####
 } else if (dataSource == "ssb") {
-    rasterisedVersion <- get_ssb(focalParameter, regionGeometry, resolution = "250")
+    rasterisedVersion <- get_ssb(focalParameter, resolution = "250")
 }

--- a/pipeline/import/utils/defineEnvSource.R
+++ b/pipeline/import/utils/defineEnvSource.R
@@ -52,13 +52,5 @@ if (dataSource == "geonorge") {
   
 ### 3. SSB ####
 } else if (dataSource == "ssb") {
-  if (file.exists("data/temp/ssb/rutenett.RDS")) { 
-    rutenett <- readRDS("data/temp/ssb/rutenett.RDS")
-    rasterisedVersion <- get_ssb(focalParameter, getRutenett = FALSE, rutenett = rutenett)
-  } else {
-    if (!dir.exists("data/temp/ssb")) {
-      dir.create("data/temp/ssb", recursive = TRUE)
-    }
-    rasterisedVersion <- get_ssb(focalParameter, regionGeometry)    
-  }
+    rasterisedVersion <- get_ssb(focalParameter, regionGeometry)
 }


### PR DESCRIPTION
# Why have changes been made?

The human density script was unnecessarily complicated, Ron found a much simpler implementation

# What changes have been made?

- pipeline/import/utils/defineEnvSource.R - Script simplified considerably since downloading the rutenett is no longer necessary
- functions/import/environment/get_ssb.R - Again, much simpler script. No need to define anything related to the rutenett. Endpoints have been updated.